### PR TITLE
Coerce keyword keys to strings in as-properties

### DIFF
--- a/src/squee/impl/util.clj
+++ b/src/squee/impl/util.clj
@@ -23,7 +23,7 @@
   [m]
   (let [p (Properties.)]
     (doseq [[k v] m]
-      (.setProperty p k v))
+      (.setProperty p (name k) v))
     p))
 
 (def ^{:doc "Map of classnames to subprotocols"} classnames


### PR DESCRIPTION
`as-properties` is (only) called by `squee.datasources/from-spec` which accepts a map with keys as keywords. However when passing additional opts in this map they need to either be strings (which in that case needs to be documented), or coerced to keywords in `as-properties`. I went for the latter. 
